### PR TITLE
Refactor with interleave-stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var PixelMultiStream = require('./lib/pixel-multi-stream')
 
 function MosaicStream (tiles, height) {
   if (!height) throw new Error('Must specify the height of the mosaic')
-  var pixelStreams = tiles.map(streams => PixelMultiStream(streams, {height: height}))
+  var pixelStreams = tiles.map(streams => PixelMultiStream(streams, height))
   return StitchImageStream(pixelStreams)
 }
 

--- a/lib/pixel-multi-stream.js
+++ b/lib/pixel-multi-stream.js
@@ -1,33 +1,48 @@
 var MultiStream = require('multistream')
 var inherits = require('inherits')
 
-function PixelMultiStream (streams, opts) {
-  if (!(this instanceof PixelMultiStream)) return new PixelMultiStream(streams, opts)
-  this.height = opts && opts.height
+/**
+ * Takes an array of multiple [pixel-streams](https://github.com/devongovett/pixel-stream)
+ * and returns a single pixel stream concatinating images vertically.
+ * All input pixel-streams must be the same width and have the same colorSpace.
+ *
+ * @param {Array} streams Array of ReadableStream or functions that return a ReadableStream
+ * @param {Number} height Total height of combined streams - must match actual height or will throw error
+ * @param {Object} opts   Passed to MultiStream with in turn passes these opts to ReadableStream
+ */
+function PixelMultiStream (streams, height, opts) {
+  if (!(this instanceof PixelMultiStream)) return new PixelMultiStream(streams, height, opts)
+  this.height = height
   MultiStream.call(this, streams, opts)
 }
 
 inherits(PixelMultiStream, MultiStream)
 
+/**
+ * Wrap the `MultiStream.prototype._gotNextStream()` which is called for each new stream.
+ * Reads the format from incoming streams and sets the format of the output stream
+ * @param {ReadableStream} stream
+ */
 PixelMultiStream.prototype._gotNextStream = function (stream) {
-  var self = this
   if (stream) {
-    setImmediate(() => self.emit('stream', stream))
     if (stream.format && stream.format.height) {
-      self._onFormat(stream.format)
+      onFormat.call(this, stream.format)
     } else {
-      stream.on('format', function (format) {
-        self._onFormat(format)
-      })
+      stream.on('format', onFormat.bind(this))
     }
-  } else if (self._actualHeight !== self.format.height) {
-    self.emit('error', new Error('Total height of mosaiced images (' + self._actualHeight +
-      'px) did not match specified height (' + self.format.height + 'px)'))
+  } else if (this._actualHeight !== this.format.height) {
+    this.emit('error', new Error('Total height of mosaiced images (' + this._actualHeight +
+      'px) did not match specified height (' + this.format.height + 'px)'))
   }
-  MultiStream.prototype._gotNextStream.call(self, stream)
+  MultiStream.prototype._gotNextStream.call(this, stream)
 }
 
-PixelMultiStream.prototype._onFormat = function (format) {
+/**
+ * When an incoming stream's format is available, read the width from the first stream and
+ * ensure that subsequent streams share the same width and colorSpace.
+ * @param {Object} format pixel-stream format object: `{ width, height, colorSpace }`
+ */
+function onFormat (format) {
   if (!this.format) {
     this.format = Object.assign({}, format, {height: this.height})
     this._actualHeight = format.height

--- a/lib/stitch-image-stream.js
+++ b/lib/stitch-image-stream.js
@@ -1,4 +1,7 @@
-var from = require('from2')
+var block = require('block-stream2')
+var interleave = require('interleave-stream')
+var pumpify = require('pumpify')
+var BufferPeekStream = require('buffer-peek-stream').BufferPeekStream
 
 // color space component counts
 var COMPONENTS = {
@@ -16,97 +19,41 @@ var COMPONENTS = {
  * @return {ReadableStream}
  */
 module.exports = function StitchImageStream (streams) {
-  var count = streams.length
-  var widths = Array(count)
-  var bufs = Array(count).fill(new Buffer(0))
-  var lineLen
-  var feedMe
-  var format
-  var readable = Array(count)
-  var pending = count
-  var mosaicedStream = from(read)
+  var pending = streams.length
+  var blockStreams = streams.map(createBlockStream)
+  var outputFormat
 
-  streams.forEach(setupStream)
+  var mosaicedStream = interleave(blockStreams)
+  var output = pumpify()
+  return output
 
-  return mosaicedStream
-
-  function read (size, next) {
-    var lineAvailable = true
-    for (var i = 0; i < count; i++) {
-      if (!widths[i] || bufs[i].length < widths[i]) {
-        lineAvailable = false
-        break
-      }
-    }
-    if (lineAvailable) {
-      var chunks = Array(count)
-      for (i = 0; i < count; i++) {
-        chunks[i] = bufs[i].slice(0, widths[i])
-        bufs[i] = bufs[i].slice(widths[i])
-      }
-      next(null, Buffer.concat(chunks, lineLen))
-    } else if (pending) {
-      feedMe = next
-      readInternal()
-    } else {
-      next(null, null)
-    }
-  }
-
-  function readInternal () {
-    for (var i = 0; i < count; i++) {
-      var isBufferFull = bufs[i].length >= widths[i]
-      if (isBufferFull || !readable[i]) continue
-      var chunk = streams[i].read()
-      if (chunk === null) continue // console.log(i, 'null')
-      bufs[i] = Buffer.concat([bufs[i], chunk])
-    }
-    if (feedMe) {
-      setImmediate(feedMe)
-      feedMe = null
-    }
-  }
-
-  function setupStream (stream, i) {
-    stream.on('readable', onReadable)
-      .on('format', onFormat)
-      .on('error', onError)
-      .on('end', onEnd)
-
-    function onReadable () {
-      readable[i] = true
-      readInternal()
-    }
-
-    function onStream (stream) {
-      stream.on('format', onFormat)
-    }
-
-    function onEnd () {
-      stream.removeListener('readable', onReadable)
-      stream.removeListener('stream', onStream)
-      stream.removeListener('format', onFormat)
-      pending--
-      readInternal()
-    }
+  function createBlockStream (stream, i) {
+    var buffer = new BufferPeekStream({peekBytes: 2})
+    var blockStream = pumpify()
+    stream.on('format', onFormat)
+    stream.on('error', onError)
+    stream.pipe(buffer)
+    return blockStream
 
     function onFormat (inputFormat) {
-      if (!format) {
-        format = Object.assign({}, inputFormat)
+      if (!outputFormat) {
+        outputFormat = Object.assign({}, inputFormat)
       } else {
-        if (inputFormat.height !== format.height) onError(new Error('input heights must be the same'))
-        if (inputFormat.colorSpace !== format.colorSpace) onError(new Error('input color spaces must be the same'))
-        format.width += inputFormat.width
+        if (inputFormat.height !== outputFormat.height) onError(new Error('input heights must be the same'))
+        if (inputFormat.colorSpace !== outputFormat.colorSpace) onError(new Error('input color spaces must be the same'))
+        outputFormat.width += inputFormat.width
       }
-      widths[i] = widths[i] || inputFormat.width * COMPONENTS[format.colorSpace]
-      if (widths.filter(Boolean).length === count) {
-        lineLen = widths.reduce((p, w) => p + w)
-        mosaicedStream.emit('format', Object.assign({}, format))
+      var inputBlockSize = inputFormat.width * COMPONENTS[outputFormat.colorSpace]
+      blockStream.setPipeline(buffer, block(inputBlockSize))
+      if (--pending === 0) {
+        var outputBlockSize = outputFormat.width * COMPONENTS[outputFormat.colorSpace]
+        output.emit('format', Object.assign({}, outputFormat))
+        output.setPipeline(mosaicedStream, block(outputBlockSize))
       }
     }
   }
 
   function onError (err) {
-    mosaicedStream.emit('error', err)
+    mosaicedStream.destroy(err)
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,16 +17,20 @@
   "author": "Gregor MacLennan",
   "license": "MIT",
   "dependencies": {
+    "block-stream2": "^1.1.0",
+    "buffer-peek-stream": "^1.0.1",
     "from2": "^2.3.0",
     "inherits": "^2.0.1",
-    "multistream": "^2.1.0"
+    "interleave-stream": "^1.0.2",
+    "multistream": "^2.1.0",
+    "pumpify": "^1.3.5"
   },
   "devDependencies": {
     "jpg-stream": "^1.1.1",
     "png-stream": "^1.0.4",
     "request": "^2.74.0",
     "standard": "^8.0.0",
-    "tilebelt": "^1.0.1"
+    "@mapbox/tilebelt": "^1.0.1"
   },
   "directories": {
     "example": "example"


### PR DESCRIPTION
The previous (hacky) way of interleaving streams did not handle backpressure so could fail under certain circumstances. Using interleave-stream this should be more robust